### PR TITLE
Add __esModule default export awareness

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "babel-plugin-import-to-require",
-  "version": "1.0.0",
+  "version": "2.0.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "babel-plugin-import-to-require",
-  "version": "1.0.0",
+  "version": "2.0.0",
   "description": "Translate import statements to require statements",
   "main": "./src/index.js",
   "license": "MIT",

--- a/src/index.js
+++ b/src/index.js
@@ -9,7 +9,9 @@ module.exports = function ({ template, types: t }) {
               const importedModule = spec.parent.source.value;
               const varName = spec.node.local.name;
               if (translate(opts.modules, importedModule)) {
-                const buildRequire = template(`const IMPORT_NAME = require(SOURCE);`);
+                const buildRequire = template(
+                  `const IMPORT_NAME = (m => m.__esModule ? m.default : m)(require(SOURCE));`
+                );
                 const newNode = buildRequire({
                   IMPORT_NAME: t.identifier(varName),
                   SOURCE: t.stringLiteral(importedModule)

--- a/test/index.js
+++ b/test/index.js
@@ -5,7 +5,7 @@ tape('should transform', t => {
   const result = babel.transform(`import foo from 'foobar';`.trim(), {
     plugins: require.resolve('../')
   });
-  t.equal(result.code, "const foo = require('foobar');");
+  t.equal(result.code, "const foo = (m => m.__esModule ? m.default : m)(require('foobar'));");
   t.end();
 });
 
@@ -22,9 +22,9 @@ import foo from 'foobar';
   t.equal(result.code, `
 const a = require('./a');
 
-const blah = require('./blah');
+const blah = (m => m.__esModule ? m.default : m)(require('./blah'));
 
-const foo = require('foobar');
+const foo = (m => m.__esModule ? m.default : m)(require('foobar'));
   `.trim());
   t.end();
 });
@@ -43,7 +43,7 @@ import foo from 'foobar';
 const a = require('./a');
 import { blah } from './blah';
 
-const foo = require('foobar');
+const foo = (m => m.__esModule ? m.default : m)(require('foobar'));
   `.trim());
   t.end();
 });
@@ -78,11 +78,11 @@ import c from 'c';
     ]
   });
   t.equal(result.code, `
-const a = require('a');
+const a = (m => m.__esModule ? m.default : m)(require('a'));
 
 import foo from 'foobar';
 
-const b = require('b');
+const b = (m => m.__esModule ? m.default : m)(require('b'));
 
 import c from 'c';
   `.trim());


### PR DESCRIPTION
Thank you for this awesome little plugin.

I thought it'd be a great addition if it followed the ES6 spec so you get the default export if __esModule is present.

This would be a breaking change, so I changed the version number to 2.0.0.

I'll be happy to hear your thoughts on this.